### PR TITLE
Fixes for case where files are deleted locally after transfer.

### DIFF
--- a/queued_storage/backends.py
+++ b/queued_storage/backends.py
@@ -179,6 +179,10 @@ class QueuedStorage(object):
         """
         cache_key = self.get_cache_key(name)
         cache.set(cache_key, False)
+
+        # Use a name that is available on both the local and remote storage
+        # systems and save locally.
+        name = self.get_available_name(name)
         name = self.local.save(name, content)
 
         # Pass on the cache key to prevent duplicate cache key creation,
@@ -217,14 +221,19 @@ class QueuedStorage(object):
 
     def get_available_name(self, name):
         """
-        Returns a filename that's free on the current storage system, and
-        available for new content to be written to.
+        Returns a filename that's free on both the local and remote storage
+        systems, and available for new content to be written to.
 
         :param name: file name
         :type name: str
         :rtype: str
         """
-        return self.get_storage(name).get_available_name(name)
+        local_available_name = self.local.get_available_name(name)
+        remote_available_name = self.remote.get_available_name(name)
+
+        if remote_available_name > local_available_name:
+            return remote_available_name
+        return local_available_name
 
     def path(self, name):
         """


### PR DESCRIPTION
These changes cover the case where files are deleted locally after transfer, and you later want to upload a file with the same name.  This is especially important for environments like Heroku where the local files are wiped out after pushing a new repository.

Specifically, `save()` calls `self.get_available_name()` before saving the file locally.  `get_available_name()` checks both the local and remote storage systems (rather than only the local) to determine the available name.

For example, consider the case where a file named `image.jpg` exists on the remote storage but not on the local storage.  You want to upload another file with the name `image.jpg` (with or without the same contents).  With these changes, both the local and remote storage systems will be checked, and the file will be uploaded as `image_1.jpg`, as appropriate.
https://docs.djangoproject.com/en/dev/howto/custom-file-storage/#django.core.files.storage.get_available_name
