### PR TITLE
update for django 1.5-1.8, python 2.6-3.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist/
 docs/_build
 *.egg
 .coverage
+*.pyc
+.project
+.pydevproject

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ python:
   - 2.6
   - 2.7
   - 3.2
-  # - 3.3
+  - 3.3
+  - 3.4
 before_install:
   - export PIP_USE_MIRRORS=true
   - export DJANGO_SETTINGS_MODULE=queued_storage.test_settings
@@ -14,16 +15,13 @@ install:
 script:
   - make test
 env:
-  - DJANGO=1.3.7
-  - DJANGO=1.4.5
-  - DJANGO=1.5.1
+  - DJANGO=1.5.12
+  - DJANGO=1.6.11
+  - DJANGO=1.7.7
+  - DJANGO=1.8
 matrix:
   exclude:
-    - python: 3.2
-      env: DJANGO=1.4.5
-    - python: 3.2
-      env: DJANGO=1.3.7
-    - python: 3.3
-      env: DJANGO=1.4.5
-    - python: 3.3
-      env: DJANGO=1.3.7
+    - python: 2.6
+      env: DJANGO=1.7.7
+    - python: 2.6
+      env: DJANGO=1.8     

--- a/queued_storage/backends.py
+++ b/queued_storage/backends.py
@@ -6,7 +6,10 @@ from django.utils.functional import SimpleLazyObject
 from django.utils.http import urlquote
 
 from queued_storage.conf import settings
-from queued_storage.utils import import_attribute
+from queued_storage.utils import import_attribute, django_version
+
+if django_version()[1] >= 7:
+    from django.utils.deconstruct import deconstructible
 
 
 class LazyBackend(SimpleLazyObject):
@@ -322,6 +325,8 @@ class QueuedStorage(object):
         :rtype: :class:`~python:datetime.datetime`
         """
         return self.get_storage(name).modified_time(name)
+if django_version()[1] >= 7:
+    QueuedStorage = deconstructible(QueuedStorage)
 
 
 class QueuedFileSystemStorage(QueuedStorage):

--- a/queued_storage/test_settings.py
+++ b/queued_storage/test_settings.py
@@ -12,6 +12,4 @@ INSTALLED_APPS = [
     'queued_storage.tests',
 ]
 
-TEST_RUNNER = 'discover_runner.DiscoverRunner'
-
 SECRET_KEY = 'top_secret'

--- a/queued_storage/utils.py
+++ b/queued_storage/utils.py
@@ -1,3 +1,4 @@
+import django
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.importlib import import_module
 
@@ -20,3 +21,7 @@ def import_attribute(import_path=None, options=None):
     except AttributeError:
         raise ImproperlyConfigured(
             'Module "%s" does not define a "%s" class.' % (module, classname))
+
+
+def django_version():
+    return [int(x) for x in django.get_version().split('.')]


### PR DESCRIPTION
The main update here is making QueuedStorage work with django1.7+ migrations by adding the ```deconstructible``` decorator.

Additionally, the travis matrix is updated to include Django 1.5-1.8 and python 2.6-3.4