### PR TITLE
fix the missing backend error string

### DIFF
--- a/queued_storage/backends.py
+++ b/queued_storage/backends.py
@@ -94,7 +94,7 @@ class QueuedStorage(object):
         if backend is None:  # pragma: no cover
             raise ImproperlyConfigured("The QueuedStorage class '%s' "
                                        "doesn't define a needed backend." %
-                                       (self, backend))
+                                       (self))
         if not isinstance(backend, six.string_types):
             raise ImproperlyConfigured("The QueuedStorage class '%s' "
                                        "requires its backends to be "


### PR DESCRIPTION
The error call breaks because the format string only has one placeholder and two arguments were given.
The `backend` argument is unnecessary, especially since the the error condition is that it is None.